### PR TITLE
Allow decrypt-in-place in `cbc_decrypt_buffer`

### DIFF
--- a/aes.c3
+++ b/aes.c3
@@ -243,8 +243,8 @@ fn void cbc_decrypt_buffer(AesCtx *ctx, char[] buf, char[] out)
 	{
 		ecb::decrypt_buffer(ctx, buf[i:aes::BLOCKLEN], &tmp);
 		xor_with_iv(&tmp, ctx.iv[..]);
-		out[i:aes::BLOCKLEN] = tmp[..];
 		ctx.iv[:aes::BLOCKLEN] = buf[i:aes::BLOCKLEN];
+		out[i:aes::BLOCKLEN] = tmp[..];
 	}
 }
 


### PR DESCRIPTION
Hi! Would like to start by saying thanks for the very easy to use port of tiny-aes! :pray: 

I was attempting to decrypt a contiguous buffer in-place with AES256-CBC and noticed the output was getting mangled.

The CBC decrypt method writes into `out` _before_ updating the IV. When `out == buf`, this causes the `ctx.iv` to get updated with the wrong value. Therefore, I have simply moved the assignment to the 'next IV' from `buf` to happen before the overwrite of `out`. In this case, all of my local test cases where `out == buf` were fixed. :)

Please feel free to double-check all tests if you have time to spare.