### PR TITLE
fix 'deprecated allocator::xyz()' warnings

### DIFF
--- a/aes.c3
+++ b/aes.c3
@@ -108,10 +108,10 @@ fn char[] decrypt(AesCtx *ctx, char[] buf, Allocator allocator) {
 	return out;
 }
 
-fn char[] encrypt_new(AesCtx *ctx, char[] buf) @inline => encrypt(ctx, buf, allocator::heap());
-fn char[] encrypt_temp(AesCtx *ctx, char[] buf) @inline => encrypt(ctx, buf, allocator::temp());
-fn char[] decrypt_new(AesCtx *ctx, char[] buf) @inline => decrypt(ctx, buf, allocator::heap());
-fn char[] decrypt_temp(AesCtx *ctx, char[] buf) @inline => decrypt(ctx, buf, allocator::temp());
+fn char[] encrypt_new(AesCtx *ctx, char[] buf) @inline => encrypt(ctx, buf, mem);
+fn char[] encrypt_temp(AesCtx *ctx, char[] buf) @inline => encrypt(ctx, buf, tmem);
+fn char[] decrypt_new(AesCtx *ctx, char[] buf) @inline => decrypt(ctx, buf, mem);
+fn char[] decrypt_temp(AesCtx *ctx, char[] buf) @inline => decrypt(ctx, buf, tmem);
 
 <*
 @param [&inout] ctx : "AES context."
@@ -189,10 +189,10 @@ fn char[] decrypt(AesCtx *ctx, char[] buf, Allocator allocator) {
 	return out;
 }
 
-fn char[] encrypt_new(AesCtx *ctx, char[] buf) @inline => encrypt(ctx, buf, allocator::heap());
-fn char[] encrypt_temp(AesCtx *ctx, char[] buf) @inline => encrypt(ctx, buf, allocator::temp());
-fn char[] decrypt_new(AesCtx *ctx, char[] buf) @inline => decrypt(ctx, buf, allocator::heap());
-fn char[] decrypt_temp(AesCtx *ctx, char[] buf) @inline => decrypt(ctx, buf, allocator::temp());
+fn char[] encrypt_new(AesCtx *ctx, char[] buf) @inline => encrypt(ctx, buf, mem);
+fn char[] encrypt_temp(AesCtx *ctx, char[] buf) @inline => encrypt(ctx, buf, tmem);
+fn char[] decrypt_new(AesCtx *ctx, char[] buf) @inline => decrypt(ctx, buf, mem);
+fn char[] decrypt_temp(AesCtx *ctx, char[] buf) @inline => decrypt(ctx, buf, tmem);
 
 fn void xor_with_iv(char[] buf, char[] iv) @local
 {
@@ -272,10 +272,10 @@ fn char[] decrypt(AesCtx *ctx, char[] buf, Allocator allocator) {
 	return out;
 }
 
-fn char[] encrypt_new(AesCtx *ctx, char[] buf) @inline => encrypt(ctx, buf, allocator::heap());
-fn char[] encrypt_temp(AesCtx *ctx, char[] buf) @inline => encrypt(ctx, buf, allocator::temp());
-fn char[] decrypt_new(AesCtx *ctx, char[] buf) @inline => decrypt(ctx, buf, allocator::heap());
-fn char[] decrypt_temp(AesCtx *ctx, char[] buf) @inline => decrypt(ctx, buf, allocator::temp());
+fn char[] encrypt_new(AesCtx *ctx, char[] buf) @inline => encrypt(ctx, buf, mem);
+fn char[] encrypt_temp(AesCtx *ctx, char[] buf) @inline => encrypt(ctx, buf, tmem);
+fn char[] decrypt_new(AesCtx *ctx, char[] buf) @inline => decrypt(ctx, buf, mem);
+fn char[] decrypt_temp(AesCtx *ctx, char[] buf) @inline => decrypt(ctx, buf, tmem);
 
 <*
 @param [&inout] ctx : "AES context."


### PR DESCRIPTION
Seems the `allocator::heap()` and `allocator::temp()` functions were recently deprecated in stdlib.

Just a quick update to fix these warnings when building downstream projects.

Used to show:
```
108:    return out;
109: }
110: 
111: fn char[] encrypt_new(AesCtx *ctx, char[] buf) @inline => encrypt(ctx, buf, allocator::heap());
                                                                                 ^^^^^^^^^^^^^^^
([..]/aes.c3l/aes.c3:111:77) Warning: 'heap' is deprecated: Use 'mem' instead..

109: }
110: 
111: fn char[] encrypt_new(AesCtx *ctx, char[] buf) @inline => encrypt(ctx, buf, allocator::heap());
112: fn char[] encrypt_temp(AesCtx *ctx, char[] buf) @inline => encrypt(ctx, buf, allocator::temp());
                                                                                  ^^^^^^^^^^^^^^^
([..]/aes.c3l/aes.c3:112:78) Warning: 'temp' is deprecated: Use 'tmem' instead.

[project build log / output]
```